### PR TITLE
Add Google Analytics

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:' + androidGradleToolsVersion
+        classpath 'com.google.gms:google-services:1.5.0-beta2'
     }
 }
 
@@ -50,5 +51,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23+'
+    compile 'com.google.android.gms:play-services-analytics:8.3.0'
     compile project(':core')
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -18,5 +18,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <service android:name="com.google.android.gms.analytics.AnalyticsService" android:enabled="true"
+                 android:exported="false"></service>
     </application>
 </manifest>

--- a/android/src/main/java/org/robovm/store/StoreAppActivity.java
+++ b/android/src/main/java/org/robovm/store/StoreAppActivity.java
@@ -23,11 +23,13 @@ import android.app.FragmentTransaction;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.view.MenuItem;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.api.RoboVMWebService;
 import org.robovm.store.api.RoboVMWebService.ActionWrapper;
 import org.robovm.store.fragments.*;
 import org.robovm.store.model.Product;
 import org.robovm.store.util.Action;
+import org.robovm.store.util.GoogleAnalyticsServiceAndroid;
 import org.robovm.store.util.ImageCache;
 import org.robovm.store.util.Images;
 
@@ -50,6 +52,8 @@ public class StoreAppActivity extends Activity {
                 runOnUiThread(() -> action.invoke(result));
             }
         };
+
+        GoogleAnalyticsService.setInstance(new GoogleAnalyticsServiceAndroid(getApplicationContext()));
 
         setContentView(R.layout.main);
 

--- a/android/src/main/java/org/robovm/store/fragments/BasketFragment.java
+++ b/android/src/main/java/org/robovm/store/fragments/BasketFragment.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.*;
 import org.robovm.store.R;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.api.RoboVMWebService;
 import org.robovm.store.model.Basket;
 import org.robovm.store.model.Order;
@@ -51,6 +52,7 @@ public class BasketFragment extends ListFragment {
 
     @Override
     public android.view.View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Basket");
         View shoppingCartView = inflater.inflate(R.layout.basket, container, false);
 
         checkoutButton = (Button) shoppingCartView.findViewById(R.id.checkoutBtn);

--- a/android/src/main/java/org/robovm/store/fragments/BragFragment.java
+++ b/android/src/main/java/org/robovm/store/fragments/BragFragment.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import org.robovm.store.R;
+import org.robovm.store.api.GoogleAnalyticsService;
 
 public class BragFragment extends Fragment {
     @Override
@@ -49,6 +50,7 @@ public class BragFragment extends Fragment {
             intent.setType("text/plain");
             intent.putExtra(Intent.EXTRA_TEXT, message);
             startActivity(Intent.createChooser(intent, getResources().getString(R.string.brag_on)));
+            GoogleAnalyticsService.getInstance().reportAnalyticEvent("Action", "Tweet", "tweet", 1);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/android/src/main/java/org/robovm/store/fragments/LoginFragment.java
+++ b/android/src/main/java/org/robovm/store/fragments/LoginFragment.java
@@ -30,6 +30,7 @@ import android.view.ViewGroup;
 import android.widget.*;
 import org.robovm.store.R;
 import org.robovm.store.api.RoboVMWebService;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.util.Gravatar;
 import org.robovm.store.views.CircleDrawable;
 
@@ -55,6 +56,7 @@ public class LoginFragment extends Fragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Login");
         if (ROBOVM_ACCOUNT_EMAIL == null || ROBOVM_ACCOUNT_EMAIL.isEmpty()) {
             return createInstructions(inflater, container, savedInstanceState);
         }
@@ -67,6 +69,7 @@ public class LoginFragment extends Fragment {
         Spanned coloredText = Html.fromHtml(
                 "<b><font color='#000080'>static</font></b> String <b><i><font color='#660E7A'>ROBOVM_ACCOUNT_EMAIL</font></i></b> = <b><font color='#008000'>\"...\"</font>;</b>");
         textView.setText(coloredText, TextView.BufferType.SPANNABLE);
+        GoogleAnalyticsService.getInstance().reportAnalyticEvent("Errors", "Missing Email", "Email", 1);
 
         return view;
     }
@@ -116,6 +119,7 @@ public class LoginFragment extends Fragment {
             } else {
                 Toast.makeText(getActivity(), "Please verify your RoboVM account credentials and try again",
                         Toast.LENGTH_LONG).show();
+                GoogleAnalyticsService.getInstance().reportAnalyticEvent("Errors", "Login Failed", "Login", 1);
             }
 
             this.login.setEnabled(true);

--- a/android/src/main/java/org/robovm/store/fragments/ProductDetailsFragment.java
+++ b/android/src/main/java/org/robovm/store/fragments/ProductDetailsFragment.java
@@ -28,6 +28,7 @@ import android.os.Bundle;
 import android.view.*;
 import android.widget.*;
 import org.robovm.store.R;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.api.RoboVMWebService;
 import org.robovm.store.model.*;
 import org.robovm.store.util.*;
@@ -84,6 +85,7 @@ public class ProductDetailsFragment extends Fragment implements ViewTreeObserver
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Product Detail");
         return inflater.inflate(R.layout.product_detail, null, true);
     }
 

--- a/android/src/main/java/org/robovm/store/fragments/ProductListFragment.java
+++ b/android/src/main/java/org/robovm/store/fragments/ProductListFragment.java
@@ -25,6 +25,7 @@ import android.view.*;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.*;
 import org.robovm.store.R;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.api.RoboVMWebService;
 import org.robovm.store.model.Basket;
 import org.robovm.store.model.Product;
@@ -48,6 +49,7 @@ public class ProductListFragment extends ListFragment {
 
     @Override
     public android.view.View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Product List");
         return inflater.inflate(R.layout.robovm_list_layout, container, false);
     }
 

--- a/android/src/main/java/org/robovm/store/fragments/ShippingDetailsFragment.java
+++ b/android/src/main/java/org/robovm/store/fragments/ShippingDetailsFragment.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.*;
 import org.robovm.store.R;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.api.RoboVMWebService;
 import org.robovm.store.api.ValidationError;
 import org.robovm.store.model.Country;
@@ -64,6 +65,7 @@ public class ShippingDetailsFragment extends Fragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Shipping Address");
         View shippingDetailsView = inflater.inflate(R.layout.shipping_details, container, false);
 
         Button placeOrder = (Button) shippingDetailsView.findViewById(R.id.placeOrder);

--- a/android/src/main/java/org/robovm/store/util/GoogleAnalyticsServiceAndroid.java
+++ b/android/src/main/java/org/robovm/store/util/GoogleAnalyticsServiceAndroid.java
@@ -1,0 +1,42 @@
+package org.robovm.store.util;
+
+import org.robovm.store.api.GoogleAnalyticsService;
+import com.google.android.gms.analytics.GoogleAnalytics;
+import com.google.android.gms.analytics.HitBuilders;
+import com.google.android.gms.analytics.Tracker;
+import android.content.Context;
+
+public class GoogleAnalyticsServiceAndroid extends GoogleAnalyticsService {
+    private static GoogleAnalytics analytics;
+    private static Tracker tracker;
+    private Context context;
+
+    public GoogleAnalyticsServiceAndroid(Context context) {
+        this.context = context;
+        startAnalyticTracking();
+    }
+
+    public void startAnalyticTracking() {
+        if (analytics == null && !showInstructions()) {
+            analytics = GoogleAnalytics.getInstance(context);
+            analytics.setDryRun(GA_IS_DRY_RUN);
+            analytics.setLocalDispatchPeriod(GA_DISPATCH_INTERVAL);
+            tracker = analytics.newTracker(GA_PROPERTY_ID);
+        }
+    }
+
+    public void reportAnalyticEvent(String category, String action, String label, int value) {
+        if (tracker != null) {
+            tracker.send(new HitBuilders.EventBuilder().setCategory(category).setAction(action).setLabel(label).setValue(value).build());
+        }
+    }
+
+    public void reportAnalyticScreen(String screenName) {
+        if (tracker != null) {
+            tracker.setScreenName(screenName);
+            tracker.send(new HitBuilders.ScreenViewBuilder().build());
+        }
+    }
+
+
+}

--- a/core/src/main/java/org/robovm/store/api/GoogleAnalyticsService.java
+++ b/core/src/main/java/org/robovm/store/api/GoogleAnalyticsService.java
@@ -1,0 +1,34 @@
+package org.robovm.store.api;
+
+import org.robovm.store.util.GoogleAnalyticsServiceDebug;
+
+public abstract class GoogleAnalyticsService {
+    // TODO: Enter your Google Analytics Property ID here
+    public static final String GA_PROPERTY_ID = ""; // example "UA-XXXXXXXX-1"
+    public static final int GA_DISPATCH_INTERVAL = 30;
+    public static final boolean GA_IS_DRY_RUN = false;
+
+    private static GoogleAnalyticsService instance = null;
+
+    public static void setInstance(GoogleAnalyticsService service) {
+        instance = service;
+    }
+
+    public static GoogleAnalyticsService getInstance() {
+        if (instance == null) {
+            setInstance(new GoogleAnalyticsServiceDebug());
+        }
+        return instance;
+    }
+
+    public boolean showInstructions() {
+        return (GA_PROPERTY_ID == null || GA_PROPERTY_ID.isEmpty());
+    }
+
+    public abstract void startAnalyticTracking();
+
+    public abstract void reportAnalyticScreen(String screen);
+
+    public abstract void reportAnalyticEvent(String category, String action, String label, int value);
+
+}

--- a/core/src/main/java/org/robovm/store/api/RoboVMWebService.java
+++ b/core/src/main/java/org/robovm/store/api/RoboVMWebService.java
@@ -146,6 +146,8 @@ public class RoboVMWebService {
     }
 
     public void placeOrder(User user, Action<APIResponse> completion) {
+        GoogleAnalyticsService.getInstance().reportAnalyticEvent("Action", "Place Order", "Order", 1);
+
         Objects.requireNonNull(user, "user");
         Objects.requireNonNull(completion);
 

--- a/core/src/main/java/org/robovm/store/util/GoogleAnalyticsServiceDebug.java
+++ b/core/src/main/java/org/robovm/store/util/GoogleAnalyticsServiceDebug.java
@@ -1,0 +1,20 @@
+package org.robovm.store.util;
+
+import org.robovm.store.api.GoogleAnalyticsService;
+
+public class GoogleAnalyticsServiceDebug extends GoogleAnalyticsService {
+    public void startAnalyticTracking() {
+        logInfo("called startAnalyticTracking");
+    }
+
+    public void reportAnalyticScreen(String screen) {
+        logInfo("called reportAnalyticScreen(" + screen + ")");
+    }
+
+    public void reportAnalyticEvent(String category, String action, String label, int value) {
+        logInfo("called reportAnalyticEvent(" + category + ", " + action + ", " + label + ", " + value + ")");
+    }
+
+    public void logInfo(String info) {
+    }
+}

--- a/ios/build.gradle
+++ b/ios/build.gradle
@@ -24,6 +24,7 @@ robovm {
 dependencies {
     compile "org.robovm:robovm-rt:${roboVMVersion}"
     compile "org.robovm:robovm-cocoatouch:${roboVMVersion}"
+    compile "org.robovm:robopods-google-analytics-ios:${roboVMVersion}"
     testCompile "junit:junit:4.12"
     compile project(':core')
 }

--- a/ios/src/main/java/org/robovm/store/StoreApp.java
+++ b/ios/src/main/java/org/robovm/store/StoreApp.java
@@ -35,11 +35,13 @@ import org.robovm.apple.uikit.UIScreen;
 import org.robovm.apple.uikit.UIStatusBarStyle;
 import org.robovm.apple.uikit.UIViewController;
 import org.robovm.apple.uikit.UIWindow;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.api.RoboVMWebService;
 import org.robovm.store.api.RoboVMWebService.ActionWrapper;
 import org.robovm.store.model.Product;
 import org.robovm.store.util.Action;
 import org.robovm.store.util.Colors;
+import org.robovm.store.util.GoogleAnalyticsServiceiOS;
 import org.robovm.store.util.ImageCache;
 import org.robovm.store.viewcontrollers.BasketViewController;
 import org.robovm.store.viewcontrollers.LoginViewController;
@@ -180,6 +182,7 @@ public class StoreApp extends UIApplicationDelegateAdapter {
 
     public static void main(String[] args) {
         try (NSAutoreleasePool pool = new NSAutoreleasePool()) {
+            GoogleAnalyticsService.setInstance(new GoogleAnalyticsServiceiOS());
             UIApplication.main(args, null, StoreApp.class);
         }
     }

--- a/ios/src/main/java/org/robovm/store/util/GoogleAnalyticsServiceiOS.java
+++ b/ios/src/main/java/org/robovm/store/util/GoogleAnalyticsServiceiOS.java
@@ -1,0 +1,39 @@
+package org.robovm.store.util;
+
+import org.robovm.apple.foundation.NSNumber;
+import org.robovm.pods.google.analytics.GAIDictionaryBuilder;
+import org.robovm.store.api.GoogleAnalyticsService;
+import org.robovm.pods.google.analytics.GAI;
+import org.robovm.pods.google.analytics.GAIFields;
+import org.robovm.pods.google.analytics.GAITracker;
+
+public class GoogleAnalyticsServiceiOS extends GoogleAnalyticsService {
+    public static GAITracker gaiTracker;
+
+    public GoogleAnalyticsServiceiOS() {
+        startAnalyticTracking();
+    }
+
+    public void startAnalyticTracking() {
+        if (gaiTracker == null && !showInstructions()) {
+            GAI gai = GAI.getSharedInstance();
+            gai.setDryRun(GA_IS_DRY_RUN);
+            gai.setDispatchInterval(GA_DISPATCH_INTERVAL);
+            gaiTracker = gai.getTracker(GA_PROPERTY_ID);
+        }
+    }
+
+    public void reportAnalyticEvent(String category, String action, String label, int value) {
+        if (gaiTracker != null) {
+            gaiTracker.send(GAIDictionaryBuilder.createEvent(category, action, label, NSNumber.valueOf(value)).build());
+        }
+    }
+
+    public void reportAnalyticScreen(String screenName) {
+        if (gaiTracker != null) {
+            gaiTracker.put(GAIFields.ScreenName(), screenName);
+            gaiTracker.send(GAIDictionaryBuilder.createScreenView().build());
+        }
+    }
+
+}

--- a/ios/src/main/java/org/robovm/store/viewcontrollers/BasketViewController.java
+++ b/ios/src/main/java/org/robovm/store/viewcontrollers/BasketViewController.java
@@ -41,6 +41,7 @@ import org.robovm.apple.uikit.UITableViewModel;
 import org.robovm.apple.uikit.UITableViewRowAnimation;
 import org.robovm.apple.uikit.UIView;
 import org.robovm.apple.uikit.UIViewContentMode;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.model.Basket;
 import org.robovm.store.model.Order;
 import org.robovm.store.util.Colors;
@@ -81,6 +82,12 @@ public class BasketViewController extends UITableViewController {
         totalAmount.sizeToFit();
         getNavigationItem().setRightBarButtonItem(new UIBarButtonItem(totalAmount));
         updateTotals();
+    }
+
+    @Override
+    public void viewDidAppear(boolean animated) {
+        super.viewDidAppear(animated);
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Basket");
     }
 
     public void updateTotals() {

--- a/ios/src/main/java/org/robovm/store/viewcontrollers/LoginViewController.java
+++ b/ios/src/main/java/org/robovm/store/viewcontrollers/LoginViewController.java
@@ -23,6 +23,7 @@ import org.robovm.apple.uikit.UIBarButtonItemStyle;
 import org.robovm.apple.uikit.UIScrollView;
 import org.robovm.apple.uikit.UIView;
 import org.robovm.apple.uikit.UIViewController;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.api.RoboVMWebService;
 import org.robovm.store.util.ProgressUI;
 import org.robovm.store.views.LoginView;
@@ -56,6 +57,12 @@ public class LoginViewController extends UIViewController {
     }
 
     @Override
+    public void viewDidAppear(boolean animated) {
+        super.viewDidAppear(animated);
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Login");
+    }
+
+    @Override
     public void viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews();
 
@@ -75,6 +82,7 @@ public class LoginViewController extends UIViewController {
         getView().addSubview(scrollView = new UIScrollView(getView().getBounds()));
         if (shouldShowInstructions()) {
             scrollView.addSubview(contentView = new PrefillRoboVMAccountInstructionsView());
+            GoogleAnalyticsService.getInstance().reportAnalyticEvent("Errors", "Missing Email", "Email", 1);
         } else {
             loginView = new LoginView(ROBOVM_ACCOUNT_EMAIL);
             loginView
@@ -104,6 +112,7 @@ public class LoginViewController extends UIViewController {
                         loginView.getPasswordField().becomeFirstResponder();
                     }
                 });
+                GoogleAnalyticsService.getInstance().reportAnalyticEvent("Errors", "Login Failed", "Login", 1);
             }
         });
     }

--- a/ios/src/main/java/org/robovm/store/viewcontrollers/ProcessingViewController.java
+++ b/ios/src/main/java/org/robovm/store/viewcontrollers/ProcessingViewController.java
@@ -39,6 +39,7 @@ import org.robovm.apple.uikit.UIView;
 import org.robovm.apple.uikit.UIViewAnimationCurve;
 import org.robovm.apple.uikit.UIViewContentMode;
 import org.robovm.apple.uikit.UIViewController;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.api.RoboVMWebService;
 import org.robovm.store.api.ValidationError;
 import org.robovm.store.model.User;
@@ -178,6 +179,7 @@ public class ProcessingViewController extends UIViewController {
                                         "I just built a native iOS app with Java using #RoboVM and all I got was this free T-shirt!");
                                 presentViewController(svc, true, null);
                             });
+            GoogleAnalyticsService.getInstance().reportAnalyticEvent("Action", "Tweet", "tweet", 1);
         }
     }
 

--- a/ios/src/main/java/org/robovm/store/viewcontrollers/ProductDetailViewController.java
+++ b/ios/src/main/java/org/robovm/store/viewcontrollers/ProductDetailViewController.java
@@ -46,6 +46,7 @@ import org.robovm.apple.uikit.UITableViewModel;
 import org.robovm.apple.uikit.UITableViewScrollPosition;
 import org.robovm.apple.uikit.UIView;
 import org.robovm.apple.uikit.UIViewContentMode;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.StoreApp;
 import org.robovm.store.model.Order;
 import org.robovm.store.model.Product;
@@ -91,6 +92,12 @@ public class ProductDetailViewController extends UITableViewController {
         bottomView.setButtonTapListener((b, e) -> addToBasket());
 
         getView().addSubview(bottomView);
+    }
+
+    @Override
+    public void viewDidAppear(boolean animated) {
+        super.viewDidAppear(animated);
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Product Detail");
     }
 
     private void addToBasket() {

--- a/ios/src/main/java/org/robovm/store/viewcontrollers/ProductListViewController.java
+++ b/ios/src/main/java/org/robovm/store/viewcontrollers/ProductListViewController.java
@@ -34,6 +34,7 @@ import org.robovm.apple.uikit.UITableViewCellSelectionStyle;
 import org.robovm.apple.uikit.UITableViewCellSeparatorStyle;
 import org.robovm.apple.uikit.UITableViewController;
 import org.robovm.apple.uikit.UITableViewModel;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.StoreApp;
 import org.robovm.store.api.RoboVMWebService;
 import org.robovm.store.model.Product;
@@ -58,6 +59,12 @@ public class ProductListViewController extends UITableViewController {
         tableView.setModel(model = new ProductListViewModel());
 
         getData();
+    }
+
+    @Override
+    public void viewDidAppear(boolean animated) {
+        super.viewDidAppear(animated);
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Product List");
     }
 
     private void getData() {

--- a/ios/src/main/java/org/robovm/store/viewcontrollers/ShippingAddressViewController.java
+++ b/ios/src/main/java/org/robovm/store/viewcontrollers/ShippingAddressViewController.java
@@ -30,6 +30,7 @@ import org.robovm.apple.uikit.UITableViewController;
 import org.robovm.apple.uikit.UITableViewModel;
 import org.robovm.apple.uikit.UITextAutocapitalizationType;
 import org.robovm.apple.uikit.UIView;
+import org.robovm.store.api.GoogleAnalyticsService;
 import org.robovm.store.model.Country;
 import org.robovm.store.model.User;
 import org.robovm.store.util.Countries;
@@ -38,6 +39,7 @@ import org.robovm.store.views.BottomButtonView;
 import org.robovm.store.views.CustomViewCell;
 import org.robovm.store.views.StringSelectionCell;
 import org.robovm.store.views.TextEntryView;
+
 
 public class ShippingAddressViewController extends UITableViewController {
     private final User user;
@@ -109,6 +111,12 @@ public class ShippingAddressViewController extends UITableViewController {
         tableView.reloadData();
 
         getView().addSubview(bottomView = new BottomButtonView("Place Order", (button, event) -> placeOrder()));
+    }
+
+    @Override
+    public void viewDidAppear(boolean animated) {
+        super.viewDidAppear(animated);
+        GoogleAnalyticsService.getInstance().reportAnalyticScreen("Shipping Address");
     }
 
     public void placeOrder() {


### PR DESCRIPTION
This patch sets up a unified Google Analytics system and adds a few event and screen tracking events.  To enagle this, set the field GA_PROPERTY_ID in GoogleAnalyticsService to enable Google Analytics.  Hooks were created for info logging and in tool warning pages.